### PR TITLE
Added dynamically resolving the path of wg

### DIFF
--- a/wgtools.py
+++ b/wgtools.py
@@ -6,7 +6,7 @@ from os import linesep
 from pathlib import Path
 from subprocess import check_call, check_output
 from typing import NamedTuple
-
+from shutil import which
 
 __all__ = [
     'WG',
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 
-WG = '/usr/bin/wg'
+WG = which('wg')
 
 
 class Keypair(NamedTuple):


### PR DESCRIPTION
Instead of having a hardcoded path for the Wireguard command, the library resolves the path using the built-in "which" util. This will allow this library to not only work on Windows but also alternative installations of Linux/OSX.